### PR TITLE
(feature) Add the possibility to work with multiple diagram roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ plugins:
       server: 'http://www.plantuml.com/plantuml' # official plantuml server
       disable_ssl_certificate_validation: true # for self-signed and invalid certs
       output_format: 'svg' # or "png"
+      allow_multiple_roots: false # in case your codebase contains more locations for diagrams (all ending in diagram_root)
       diagram_root: 'docs/diagrams' # should reside under docs_dir
       output_folder: 'out'
       input_folder: 'src'


### PR DESCRIPTION
We use this plugin with a very large code repository, and use mkdocs with the monorepo plugin to allow for documentation throughout the repository.

This feature adds the functionality to have multiple diagram roots, directories ending on `docs/diagrams`, in the repository. Which will make the plugin keep track on the different roots, allowing our developers creating diagrams within their own module.

This behaviour is activated by a new config key "allow_multiple_roots" which is false by default