### PR TITLE
Update Versions

### DIFF
--- a/.github/workflows/pypi_ci.yaml
+++ b/.github/workflows/pypi_ci.yaml
@@ -42,7 +42,7 @@ jobs:
       id-token: write    
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/pypi_ci.yaml
+++ b/.github/workflows/pypi_ci.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pipy
-      url: https://pypi.org/p/mkdocs-build-plantuml-plugin
+      url: https://testpi.org/p/mkdocs-build-plantuml-plugin
     permissions:
       id-token: write    
     steps:

--- a/.github/workflows/pypi_ci.yaml
+++ b/.github/workflows/pypi_ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies and build distribution packages
@@ -24,7 +24,7 @@ jobs:
           python setup.py sdist bdist_wheel
           twine check dist/*
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/testpi_ci.yaml
+++ b/.github/workflows/testpi_ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies and build distribution packages
@@ -23,7 +23,7 @@ jobs:
           python setup.py sdist bdist_wheel
           twine check dist/*
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/testpi_ci.yaml
+++ b/.github/workflows/testpi_ci.yaml
@@ -41,7 +41,7 @@ jobs:
       id-token: write    
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/testpi_ci.yaml
+++ b/.github/workflows/testpi_ci.yaml
@@ -28,14 +28,14 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-pypi:
-    name: Publish Python distribution package to PyPI
-    if: ${{ github.repository == 'quantorconsulting/mkdocs_build_plantuml' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') }}
+  publish-to-testpi:
+    name: Publish Python distribution package to TestPI
+    if: ${{ github.ref == 'refs/heads/test' }}
     needs: 
       - build-python-package
     runs-on: ubuntu-latest
     environment:
-      name: pipy
+      name: testpy
       url: https://testpi.org/p/mkdocs-build-plantuml-plugin
     permissions:
       id-token: write    
@@ -45,13 +45,13 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Publish distribution packages to PyPI
+      - name: Publish distribution packages to TestPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
   add-git-tag:
     name: Add version tag to repository
     needs: 
-      - publish-to-pypi
+      - publish-to-testpi
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testpi_ci.yaml
+++ b/.github/workflows/testpi_ci.yaml
@@ -2,8 +2,7 @@ name: Publish python package to PyPi
 on:
   push:
     branches:
-      - master
-      - main
+      - test
 
 permissions:
   contents: write
@@ -37,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pipy
-      url: https://pypi.org/p/mkdocs-build-plantuml-plugin
+      url: https://testpi.org/p/mkdocs-build-plantuml-plugin
     permissions:
       id-token: write    
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
-# Vs Code
+# IDE
 .vscode/
+.idea/
 
 # Python virtual environments
 .venv

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You need to have installed:
 - [MkDocs](https://www.mkdocs.org)
 - Java for Plantuml (If running locally)
 - [Plantuml](https://plantuml.com) (if running locally)
-- This plugin (needs httplib2 for server rendering)
+- This plugin (needs [httplib2](https://pypi.org/project/httplib2/) for server rendering)
 
 On macOS you can install plantuml with homebrew which puts a plantuml executable in `/usr/local/bin/plantuml`.
 

--- a/mkdocs_build_plantuml_plugin/plantuml.py
+++ b/mkdocs_build_plantuml_plugin/plantuml.py
@@ -171,6 +171,7 @@ class BuildPlantumlPlugin(BasePlugin[BuildPlantumlPluginConfig]):
         diagram.inc_time = 0
 
     def _readFile(self, diagram, dark_mode):
+        print(f"Reading {diagram.src_file}")
         temp_file = self._readFileRecursively(
             diagram.src_file, "", diagram, diagram.directory, dark_mode
         )

--- a/mkdocs_build_plantuml_plugin/plantuml.py
+++ b/mkdocs_build_plantuml_plugin/plantuml.py
@@ -171,7 +171,7 @@ class BuildPlantumlPlugin(BasePlugin[BuildPlantumlPluginConfig]):
         diagram.inc_time = 0
 
     def _readFile(self, diagram, dark_mode):
-        print(f"Reading {diagram.src_file}")
+        print(f"Processing diagram {diagram.file} {diagram.src_file}")
         temp_file = self._readFileRecursively(
             diagram.src_file, "", diagram, diagram.directory, dark_mode
         )

--- a/mkdocs_build_plantuml_plugin/plantuml.py
+++ b/mkdocs_build_plantuml_plugin/plantuml.py
@@ -171,7 +171,7 @@ class BuildPlantumlPlugin(BasePlugin[BuildPlantumlPluginConfig]):
         diagram.inc_time = 0
 
     def _readFile(self, diagram, dark_mode):
-        print(f"Processing diagram {diagram.file} {diagram.src_file}")
+        print(f"Processing diagram {diagram.file}")
         temp_file = self._readFileRecursively(
             diagram.src_file, "", diagram, diagram.directory, dark_mode
         )


### PR DESCRIPTION
#35 
I made the following updates:

* updated versions for github actions : Node 16 -> Node 20
  * setup-python
  * upload-artifact
  * download-artifact
* testing support
  * I created a testpy_ci.yaml for publishing to testpy (I could not push though because you already have one (oops))
  * To test I found that `pip install mkdocs_build_plantuml_plugin@git+https://github.com/babeloff/mkdocs_build_plantuml` works 
     * This might be a good thing to add to the documentation
* IDE : I use PyCharm so I added `.idea/` to the `.gitignore`
* In the README I made the `httplib2` dependency a link to make it clearer that it needs to be installed
* I ported all the `os.path` stuff to use `pathlib` 
* I changed the URL for the PlantUML server to use `https`
* On the include file processing I changed it to test for the file existence rather than catching the exception.
* I changed a number of places where strings are constructed to use the  `f"..."` formatted string
* I added a message indicating what diagram is being processed earlier in the flow. The exception I was getting happened before the `Converting` message

I think that is all.